### PR TITLE
fix Contao Manager Plugin

### DIFF
--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -13,6 +13,11 @@ use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
 
+use Trilobit\FormvalidationBundle\TrilobitFormvalidationBundle;
+use Contao\CoreBundle\ContaoCoreBundle;
+use Contao\CommentsBundle\ContaoCommentsBundle;
+use Contao\NewsletterBundle\ContaoNewsletterBundle;
+
 /**
  * Plugin for the Contao Manager.
  */
@@ -24,8 +29,8 @@ class Plugin implements BundlePluginInterface
     public function getBundles(ParserInterface $parser)
     {
         return [
-            BundleConfig::create('Trilobit\FormvalidationBundle\TrilobitFormvalidationBundle')
-                ->setLoadAfter([ContaoCoreBundle::class, 'comments']),
+            BundleConfig::create(TrilobitFormvalidationBundle::class)
+                ->setLoadAfter([ContaoCoreBundle::class, ContaoCommentsBundle::class, ContaoNewsletterBundle::class]),
         ];
     }
 }


### PR DESCRIPTION
* The `setLoadAfter` array had `ContaoCoreBundle::class` - however, there was no `use Contao\CoreBundle\ContaoCoreBundle;` statement and thus it never worked.
* Instead of `'comments'` it should use `\Contao\CommentsBundle\ContaoCommentsBundle::class`.
* The dependency to the newsletter bundle was missing.